### PR TITLE
Client can now parse metadata from server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@
 ### Breaking Changes
 - `send(client, path)` → `send(client, path, queue_name)`: Python callers must now pass the target queue name as a third argument.
 - Request frame format updated to match DataBroker server protocol. Old frame: `[1b cmd][8b payload_size][payload]`. New frame: `[1b cmd][16b client_id][8b payload_size][64b queue_name][payload]`.
+- `send()` return type now varies by command:
+  - **Dequeue (2)**: returns `tuple(MessageMeta, bytes)` instead of raw bytes.
+  - **PeekM (5)**: returns `list[MessageMeta]` instead of raw bytes.
+  - All other commands still return `bytes`.
 
 ### Added
+- `MessageMeta` Python class with fields `id`, `publisher_id`, `timestamp`, `locked_by` — parsed from the server's 56-byte Meta format.
+- Client-side parsing of server Meta on Dequeue and PeekM responses.
 - `BrokerClient` now carries a `client_id: u128` generated at connect time (system clock based).
 - New request commands mirroring the server: `CreateQ (3)`, `DeleteQ (4)`, `PeekM (5)`, `DeleteM (6)`, `Succeeded (7)`, `Failed (8)`, `Requeue (9)`, `UpdateM (10)`.
 - Queue name is null-padded to 64 bytes on the wire as required by the server.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,12 @@ cargo run -- --address 192.168.1.5:9000
 **Core Client (`src/net/client.rs`)**
 - `BrokerClient`: wraps a TCP stream and a `client_id: u128`; wrapped in `Arc<Mutex<>>` for thread safety
 - `PyBrokerClient`: thin PyO3-visible wrapper around `BrokerClient`
+- `MessageMeta`: PyO3-visible struct with fields `id: u128`, `publisher_id: u128`, `timestamp: u64`, `locked_by: Option<u128>` — parsed from the server's 56-byte Meta format (big-endian, `u128::MAX` → `None` for `locked_by`)
 - `client_send()` sends a request (any command) with a `Vec<u8>` payload, then awaits and returns the server's response payload as `Vec<u8>`
+- Response parsing varies by command:
+  - **Dequeue (2)**: returns `tuple(MessageMeta, bytes)` — meta separated from payload
+  - **PeekM (5)**: returns `list[MessageMeta]` — one entry per 56-byte chunk
+  - **All others**: returns raw `bytes`
 - Binary protocol (big-endian, matches DataBroker server):
   - Request: `[1 byte command][16 bytes client_id u128 BE][8 bytes payload_size u64 BE][64 bytes queue_name null-padded][payload]`
   - Response: `[1 byte status][8 bytes payload_size u64 BE][payload]`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-﻿use std::sync::OnceLock;
+use std::sync::OnceLock;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3_asyncio::tokio::init_with_runtime;
 use tokio::runtime::Runtime;
-use crate::net::client::{client_connect, client_send, PyBrokerClient};
+use crate::net::client::{client_connect, client_send, PyBrokerClient, MessageMeta, parse_peek_response, parse_dequeue_response};
 mod net;
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
@@ -34,7 +34,32 @@ unsafe fn send<'py>(py: Python<'py>, client: &PyBrokerClient, command: u8, paylo
     let client = client.client.clone();
     pyo3_asyncio::tokio::future_into_py(py, async move {
         match client_send(client, command, payload, &queue_name).await {
-            Ok(response) => Ok(response),
+            Ok(response) => {
+                Python::with_gil(|py| {
+                    match command {
+                        // PeekM - return list of MessageMeta
+                        5 => {
+                            let metas = parse_peek_response(&response);
+                            let py_list: Vec<PyObject> = metas.into_iter()
+                                .map(|m| Py::new(py, m).unwrap().into_py(py))
+                                .collect();
+                            Ok(py_list.into_py(py))
+                        }
+                        // Dequeue - return (MessageMeta, bytes)
+                        2 => {
+                            if response.len() < 56 {
+                                return Ok(response.into_py(py));
+                            }
+                            let (meta, data) = parse_dequeue_response(&response);
+                            let py_meta = Py::new(py, meta).unwrap();
+                            let py_tuple = (py_meta, data).into_py(py);
+                            Ok(py_tuple)
+                        }
+                        // Everything else - return raw bytes
+                        _ => Ok(response.into_py(py)),
+                    }
+                })
+            }
             Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!("failed to send, {err}"))),
         }
     })
@@ -43,6 +68,7 @@ unsafe fn send<'py>(py: Python<'py>, client: &PyBrokerClient, command: u8, paylo
 fn data_broker_client(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     let rt: &'static Runtime = get_runtime();
     let _ = init_with_runtime(rt);
+    m.add_class::<MessageMeta>()?;
     m.add_function(wrap_pyfunction!(connect, m)?)?;
     m.add_function(wrap_pyfunction!(send, m)?)?;
     Ok(())

--- a/src/net/client.rs
+++ b/src/net/client.rs
@@ -1,10 +1,13 @@
 use std::io::ErrorKind;
 use std::sync::Arc;
+use pyo3::prelude::*;
 use pyo3::pyclass;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::{Mutex};
 use bytes::BytesMut;
+
+const META_SIZE: usize = 56;
 
 #[derive(Debug, Clone)]
 pub struct BrokerClient {
@@ -14,6 +17,38 @@ pub struct BrokerClient {
 #[pyclass]
 pub struct PyBrokerClient {
     pub client: Arc<Mutex<BrokerClient>>,
+}
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct MessageMeta {
+    #[pyo3(get)]
+    pub id: u128,
+    #[pyo3(get)]
+    pub publisher_id: u128,
+    #[pyo3(get)]
+    pub timestamp: u64,
+    #[pyo3(get)]
+    pub locked_by: Option<u128>,
+}
+impl MessageMeta {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let id = u128::from_be_bytes(bytes[0..16].try_into().unwrap());
+        let publisher_id = u128::from_be_bytes(bytes[16..32].try_into().unwrap());
+        let timestamp = u64::from_be_bytes(bytes[32..40].try_into().unwrap());
+        let locked_raw = u128::from_be_bytes(bytes[40..56].try_into().unwrap());
+        let locked_by = if locked_raw == u128::MAX { None } else { Some(locked_raw) };
+        MessageMeta { id, publisher_id, timestamp, locked_by }
+    }
+}
+pub fn parse_peek_response(payload: &[u8]) -> Vec<MessageMeta> {
+    payload.chunks_exact(META_SIZE)
+        .map(MessageMeta::from_bytes)
+        .collect()
+}
+pub fn parse_dequeue_response(payload: &[u8]) -> (MessageMeta, Vec<u8>) {
+    let meta = MessageMeta::from_bytes(&payload[..META_SIZE]);
+    let data = payload[META_SIZE..].to_vec();
+    (meta, data)
 }
 #[repr(u8)]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
`send()` return type now varies by command:   
                                                                                                                                                                                                   
* **Dequeue (2)**: returns `tuple(MessageMeta, bytes)` instead of raw bytes.                                                                                                                                                                       
* **PeekM (5)**: returns `list[MessageMeta]` instead of raw bytes.                                                                                                                                                                                        
* All other commands still return `bytes`.    