### PR TITLE
Rename PeekM to ListM to match server, fix client bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,23 @@
 - Request frame format updated to match DataBroker server protocol. Old frame: `[1b cmd][8b payload_size][payload]`. New frame: `[1b cmd][16b client_id][8b payload_size][64b queue_name][payload]`.
 - `send()` return type now varies by command:
   - **Dequeue (2)**: returns `tuple(MessageMeta, bytes)` instead of raw bytes.
-  - **PeekM (5)**: returns `list[MessageMeta]` instead of raw bytes.
+  - **ListM (5)**: returns `list[MessageMeta]` instead of raw bytes.
   - All other commands still return `bytes`.
 
 ### Added
 - `MessageMeta` Python class with fields `id`, `publisher_id`, `timestamp`, `locked_by` — parsed from the server's 56-byte Meta format.
-- Client-side parsing of server Meta on Dequeue and PeekM responses.
+- Client-side parsing of server Meta on Dequeue and ListM responses.
 - `BrokerClient` now carries a `client_id: u128` generated at connect time (system clock based).
-- New request commands mirroring the server: `CreateQ (3)`, `DeleteQ (4)`, `PeekM (5)`, `DeleteM (6)`, `Succeeded (7)`, `Failed (8)`, `Requeue (9)`, `UpdateM (10)`.
+- New request commands mirroring the server: `CreateQ (3)`, `DeleteQ (4)`, `ListM (5)`, `DeleteM (6)`, `Succeeded (7)`, `Failed (8)`, `Requeue (9)`, `UpdateM (10)`.
 - Queue name is null-padded to 64 bytes on the wire as required by the server.
+
+### Fixed
+- `Response::from_u8` no longer panics on unknown status bytes; returns a proper error instead.
+- `receive()` no longer spins infinitely on server disconnect; detects EOF and returns `UnexpectedEof`.
+- `client_id` generation uses a single `SystemTime::now()` call to avoid clock-tick race.
+- `client_send` holds the outer `BrokerClient` lock across send+receive to prevent concurrent call interleaving.
+- `send()` now propagates the original I/O error instead of swallowing it.
+- `client_connect` uses idiomatic `match` instead of fragile `is_ok()` + `?` pattern.
 
 ## [0.2.1]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,12 @@ cargo run -- --address 192.168.1.5:9000
 - `client_send()` sends a request (any command) with a `Vec<u8>` payload, then awaits and returns the server's response payload as `Vec<u8>`
 - Response parsing varies by command:
   - **Dequeue (2)**: returns `tuple(MessageMeta, bytes)` — meta separated from payload
-  - **PeekM (5)**: returns `list[MessageMeta]` — one entry per 56-byte chunk
+  - **ListM (5)**: returns `list[MessageMeta]` — one entry per 56-byte chunk
   - **All others**: returns raw `bytes`
 - Binary protocol (big-endian, matches DataBroker server):
   - Request: `[1 byte command][16 bytes client_id u128 BE][8 bytes payload_size u64 BE][64 bytes queue_name null-padded][payload]`
   - Response: `[1 byte status][8 bytes payload_size u64 BE][payload]`
-  - Request commands: `Enqueue = 1`, `Dequeue = 2`, `CreateQ = 3`, `DeleteQ = 4`, `PeekM = 5`, `DeleteM = 6`, `Succeeded = 7`, `Failed = 8`, `Requeue = 9`, `UpdateM = 10`
+  - Request commands: `Enqueue = 1`, `Dequeue = 2`, `CreateQ = 3`, `DeleteQ = 4`, `ListM = 5`, `DeleteM = 6`, `Succeeded = 7`, `Failed = 8`, `Requeue = 9`, `UpdateM = 10`
   - Response codes: `Succeeded = 1`, `Failed = 2`
 - `client_id` is generated at connect time from the system clock (secs << 64 | subsec_nanos)
 - `receive()` guards `buffer.len() >= 9 + payload_size` before calling `parse_message`, so `parse_message` always has a complete frame in the buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3_asyncio::tokio::init_with_runtime;
 use tokio::runtime::Runtime;
-use crate::net::client::{client_connect, client_send, PyBrokerClient, MessageMeta, parse_peek_response, parse_dequeue_response};
+use crate::net::client::{client_connect, client_send, PyBrokerClient, MessageMeta, parse_list_response, parse_dequeue_response};
 mod net;
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
@@ -37,9 +37,9 @@ unsafe fn send<'py>(py: Python<'py>, client: &PyBrokerClient, command: u8, paylo
             Ok(response) => {
                 Python::with_gil(|py| {
                     match command {
-                        // PeekM - return list of MessageMeta
+                        // ListM - return list of MessageMeta
                         5 => {
-                            let metas = parse_peek_response(&response);
+                            let metas = parse_list_response(&response);
                             let py_list: Vec<PyObject> = metas.into_iter()
                                 .map(|m| Py::new(py, m).unwrap().into_py(py))
                                 .collect();

--- a/src/net/client.rs
+++ b/src/net/client.rs
@@ -40,7 +40,7 @@ impl MessageMeta {
         MessageMeta { id, publisher_id, timestamp, locked_by }
     }
 }
-pub fn parse_peek_response(payload: &[u8]) -> Vec<MessageMeta> {
+pub fn parse_list_response(payload: &[u8]) -> Vec<MessageMeta> {
     payload.chunks_exact(META_SIZE)
         .map(MessageMeta::from_bytes)
         .collect()
@@ -57,7 +57,7 @@ pub enum Request {
     Dequeue = 2,
     CreateQ = 3,
     DeleteQ = 4,
-    PeekM = 5,
+    ListM = 5,
     DeleteM = 6,
     Succeeded = 7,
     Failed = 8,
@@ -71,7 +71,7 @@ impl Request {
             2 => Ok(Request::Dequeue),
             3 => Ok(Request::CreateQ),
             4 => Ok(Request::DeleteQ),
-            5 => Ok(Request::PeekM),
+            5 => Ok(Request::ListM),
             6 => Ok(Request::DeleteM),
             7 => Ok(Request::Succeeded),
             8 => Ok(Request::Failed),
@@ -88,11 +88,11 @@ enum Response {
     Failed = 2,
 }
 impl Response {
-    pub(crate) fn from_u8(value: u8) -> Self {
+    pub(crate) fn from_u8(value: u8) -> Result<Self, std::io::Error> {
         match value {
-            1 => Response::Succeeded,
-            2 => Response::Failed,
-            _ => unimplemented!(),
+            1 => Ok(Response::Succeeded),
+            2 => Ok(Response::Failed),
+            _ => Err(std::io::Error::new(ErrorKind::InvalidData, format!("unknown response status: {}", value))),
         }
     }
 }
@@ -138,7 +138,7 @@ impl ResponseMessage {
 }
 fn parse_message(buffer: &mut BytesMut) -> Result<ResponseMessage, std::io::Error> {
     let payload_size = u64::from_be_bytes(buffer[1..9].try_into().unwrap());
-    let message = ResponseMessage::new(Response::from_u8(buffer[0]),
+    let message = ResponseMessage::new(Response::from_u8(buffer[0])?,
                                        payload_size,
                                        buffer.split_to(payload_size as usize + 9)[9..].to_vec());
     Ok(message)
@@ -149,9 +149,8 @@ impl BrokerClient {
             stream: Arc::new(Mutex::new(stream)),
             client_id: {
                 use std::time::{SystemTime, UNIX_EPOCH};
-                let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().subsec_nanos();
-                let secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-                ((secs as u128) << 64) | (nanos as u128)
+                let duration = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+                ((duration.as_secs() as u128) << 64) | (duration.subsec_nanos() as u128)
             },
         }
     }
@@ -163,19 +162,20 @@ impl BrokerClient {
             payload_size: payload.len() as u64,
             payload,
         };
-        if self.stream.lock().await.write_all(&request_message.as_bytes()).await.is_err() {
-            return Err(std::io::Error::new(ErrorKind::Other, "failed to send"))?
-        }
+        self.stream.lock().await.write_all(&request_message.as_bytes()).await?;
         Ok(())
     }
     pub(crate) async fn receive(self) -> Result<Vec<u8>, std::io::Error> {
         let mut buffer = BytesMut::with_capacity(1024*4);
         loop {
-            self.stream.lock().await.read_buf(&mut buffer).await?;
+            let n = self.stream.lock().await.read_buf(&mut buffer).await?;
+            if n == 0 {
+                return Err(std::io::Error::new(ErrorKind::UnexpectedEof, "server closed connection"));
+            }
             if buffer.len() >= 9 {
                 let payload_size = u64::from_be_bytes(buffer[1..9].try_into().unwrap());
                 if buffer.len() >= payload_size as usize + 9 {
-                    match Response::from_u8(buffer[0]) {
+                    match Response::from_u8(buffer[0])? {
                         Response::Succeeded => {
                             let response = parse_message(&mut buffer)?;
                             return Ok(response.payload);
@@ -194,17 +194,18 @@ impl BrokerClient {
 }
 pub async fn client_send(client: Arc<Mutex<BrokerClient>>, command: u8, payload: Vec<u8>, queue_name: &String) -> Result<Vec<u8>, std::io::Error> {
     let command = Request::from_u8(command)?;
-    let broker = client.lock().await.clone();
-    broker.clone().send(command, payload, queue_name).await?;
-    broker.receive().await
+    let broker = client.lock().await;
+    let inner = broker.clone();
+    inner.clone().send(command, payload, queue_name).await?;
+    inner.receive().await
 }
 pub async fn client_connect(url: String) -> Result<Arc<Mutex<BrokerClient>>, std::io::Error> {
     println!("Connecting to server...");
-    let stream = TcpStream::connect(url).await;
-    if stream.is_ok() {
-        println!("Connected to server");
-        let broker_client = Arc::new(Mutex::new(BrokerClient::new(stream?)));
-        return Ok(broker_client)
+    match TcpStream::connect(url).await {
+        Ok(stream) => {
+            println!("Connected to server");
+            Ok(Arc::new(Mutex::new(BrokerClient::new(stream))))
+        }
+        Err(err) => Err(std::io::Error::new(ErrorKind::Other, format!("failed to connect: {err}")))
     }
-    Err(std::io::Error::new(ErrorKind::Other, "failed to connect"))?
 }


### PR DESCRIPTION
Naming alignment with server:                                                                                                                                                                                                                                       

- Renamed PeekM → ListM (command 5) in client enum, parser function, and all references in lib.rs, CLAUDE.md, and CHANGELOG.md                                                                                                                                                                                                                                                                                                                                                                                                              Bug fixes found by review agent:                                                                                                                                                                                                                                    
1. Response::from_u8 panic — replaced unimplemented!() with proper Result error                                                                                                                                                                             
3. receive() EOF spin — added n == 0 check returning UnexpectedEof                                                                                                                                                                                                    
4. client_id race — single SystemTime::now() call instead of two                                                                                                                                                                                                    

5. Send/receive interleaving — client_send now holds the outer BrokerClient lock across both operations                                                                                                                                                               
6. Swallowed error in send() — now propagates the original I/O error                                                                                                                                                                                                
7. Fragile client_connect — uses match instead of is_ok() + ? 