### PR TITLE
Fix protocol mismatches, concurrency bugs, and error handling in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-- `receive()` now holds the stream lock for the entire read loop instead of releasing and re-acquiring it per iteration, preventing potential data loss from interleaved reads.
-- Failed server responses (2-byte big-endian `u16` error codes) are now correctly parsed and mapped to human-readable error messages via `error_code_message()`, instead of being misinterpreted as UTF-8 strings.
-- `payload_size` is now converted from `u64` to `usize` via `try_into()` with a checked addition for the frame header, preventing silent truncation on 32-bit platforms and arithmetic overflow.
-- `send()` now rejects queue names longer than 64 bytes with an explicit error instead of silently truncating them.
-- `BrokerClient::send()` parameter changed from `&String` to `&str` for idiomatic Rust usage.
-
 ### Breaking Changes
 - `send(client, path)` → `send(client, path, queue_name)`: Python callers must now pass the target queue name as a third argument.
 - Request frame format updated to match DataBroker server protocol. Old frame: `[1b cmd][8b payload_size][payload]`. New frame: `[1b cmd][16b client_id][8b payload_size][64b queue_name][payload]`.
@@ -24,8 +17,14 @@
 - `BrokerClient` now carries a `client_id: u128` generated at connect time (system clock based).
 - New request commands mirroring the server: `CreateQ (3)`, `DeleteQ (4)`, `ListM (5)`, `DeleteM (6)`, `Succeeded (7)`, `Failed (8)`, `Requeue (9)`, `UpdateM (10)`.
 - Queue name is null-padded to 64 bytes on the wire as required by the server.
+- `error_code_message()` maps all 18 server error codes (0–303) to human-readable strings.
 
 ### Fixed
+- Failed server responses (2-byte big-endian `u16` error codes) are now correctly parsed and mapped to human-readable error messages, instead of being misinterpreted as UTF-8 strings.
+- `receive()` now holds the stream lock for the entire read loop instead of releasing and re-acquiring it per iteration, preventing potential data loss from interleaved reads.
+- `payload_size` is now converted from `u64` to `usize` via `try_into()` with a checked addition for the frame header, preventing silent truncation on 32-bit platforms and arithmetic overflow.
+- `send()` now rejects queue names longer than 64 bytes with an explicit error instead of silently truncating them.
+- `BrokerClient::send()` parameter changed from `&String` to `&str` for idiomatic Rust usage.
 - `BrokerClient::send` and `receive` now take `&self` instead of consuming `self`, eliminating unnecessary clones in `client_send`.
 - `parse_dequeue_response` now validates payload length (>= 56 bytes) and returns `Result` instead of panicking on short responses.
 - `client_send` no longer clones `BrokerClient`; it borrows through the held mutex guard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+- `receive()` now holds the stream lock for the entire read loop instead of releasing and re-acquiring it per iteration, preventing potential data loss from interleaved reads.
+- Failed server responses (2-byte big-endian `u16` error codes) are now correctly parsed and mapped to human-readable error messages via `error_code_message()`, instead of being misinterpreted as UTF-8 strings.
+- `payload_size` is now converted from `u64` to `usize` via `try_into()` with a checked addition for the frame header, preventing silent truncation on 32-bit platforms and arithmetic overflow.
+- `send()` now rejects queue names longer than 64 bytes with an explicit error instead of silently truncating them.
+- `BrokerClient::send()` parameter changed from `&String` to `&str` for idiomatic Rust usage.
+
 ### Breaking Changes
 - `send(client, path)` → `send(client, path, queue_name)`: Python callers must now pass the target queue name as a third argument.
 - Request frame format updated to match DataBroker server protocol. Old frame: `[1b cmd][8b payload_size][payload]`. New frame: `[1b cmd][16b client_id][8b payload_size][64b queue_name][payload]`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ cargo run -- --address 192.168.1.5:9000
 - `PyBrokerClient`: thin PyO3-visible wrapper around `BrokerClient`
 - `MessageMeta`: PyO3-visible struct with fields `id: u128`, `publisher_id: u128`, `timestamp: u64`, `locked_by: Option<u128>` — parsed from the server's 56-byte Meta format (big-endian, `u128::MAX` → `None` for `locked_by`)
 - `client_send()` sends a request (any command) with a `Vec<u8>` payload, then awaits and returns the server's response payload as `Vec<u8>`
+- Failed responses are parsed as 2-byte big-endian `u16` error codes matching the server's `ErrorCode` enum, and converted to human-readable error messages via `error_code_message()`
 - Response parsing varies by command:
   - **Dequeue (2)**: returns `tuple(MessageMeta, bytes)` — meta separated from payload
   - **ListM (5)**: returns `list[MessageMeta]` — one entry per 56-byte chunk
@@ -47,7 +48,9 @@ cargo run -- --address 192.168.1.5:9000
   - Request commands: `Enqueue = 1`, `Dequeue = 2`, `CreateQ = 3`, `DeleteQ = 4`, `ListM = 5`, `DeleteM = 6`, `Succeeded = 7`, `Failed = 8`, `Requeue = 9`, `UpdateM = 10`, `UpdateQ = 11`
   - Response codes: `Succeeded = 1`, `Failed = 2`
 - `client_id` is generated at connect time from the system clock (secs << 64 | subsec_nanos)
-- `receive()` guards `buffer.len() >= 9 + payload_size` before calling `parse_message`, so `parse_message` always has a complete frame in the buffer
+- `receive()` holds the stream lock for the entire read loop (not per-iteration) and guards `buffer.len() >= 9 + payload_size` before calling `parse_message`
+- `payload_size` is converted from `u64` to `usize` via `try_into()` with overflow checks, safe on both 32-bit and 64-bit platforms
+- Queue names are validated to not exceed 64 bytes before sending
 
 **CI/CD (`.github/workflows/`)**
 - `build.yml`: builds wheels for Python 3.10/3.11/3.12 on Ubuntu and Windows on every push/PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "DataBrokerClient"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "DataBrokerClient"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [lib]

--- a/src/net/client.rs
+++ b/src/net/client.rs
@@ -141,11 +141,47 @@ impl ResponseMessage {
         }
     }
 }
+fn error_code_message(code: u16) -> &'static str {
+    match code {
+        0   => "unknown request type",
+        1   => "failed to parse request message",
+        2   => "failed to send response",
+        3   => "payload exceeds maximum size",
+        100 => "queue hash not found",
+        101 => "queue not found",
+        102 => "queue already exists",
+        103 => "queue does not exist",
+        104 => "queue is empty",
+        200 => "payload missing message id",
+        201 => "no such message id",
+        202 => "message already locked",
+        203 => "no such message id locked",
+        204 => "message not locked by client",
+        205 => "message not in queue",
+        300 => "invalid config payload size",
+        301 => "config bytes empty",
+        302 => "invalid config auto_fail",
+        303 => "invalid config fail_timeout",
+        _   => "unknown error",
+    }
+}
+fn parse_error_payload(payload: &[u8]) -> String {
+    if payload.len() >= 2 {
+        let code = u16::from_be_bytes([payload[0], payload[1]]);
+        format!("server error {}: {}", code, error_code_message(code))
+    } else {
+        "server returned error with no details".to_string()
+    }
+}
 fn parse_message(buffer: &mut BytesMut) -> Result<ResponseMessage, std::io::Error> {
     let payload_size = u64::from_be_bytes(buffer[1..9].try_into().unwrap());
+    let payload_len: usize = payload_size.try_into()
+        .map_err(|_| std::io::Error::new(ErrorKind::InvalidData, "payload size exceeds platform limit"))?;
+    let total = payload_len.checked_add(9)
+        .ok_or_else(|| std::io::Error::new(ErrorKind::InvalidData, "payload size overflow"))?;
     let message = ResponseMessage::new(Response::from_u8(buffer[0])?,
                                        payload_size,
-                                       buffer.split_to(payload_size as usize + 9)[9..].to_vec());
+                                       buffer.split_to(total)[9..].to_vec());
     Ok(message)
 }
 impl BrokerClient {
@@ -159,11 +195,14 @@ impl BrokerClient {
             },
         }
     }
-    pub(crate) async fn send(&self, command: Request, payload: Vec<u8>, queue_name: &String) -> Result<(), std::io::Error> {
+    pub(crate) async fn send(&self, command: Request, payload: Vec<u8>, queue_name: &str) -> Result<(), std::io::Error> {
+        if queue_name.len() > 64 {
+            return Err(std::io::Error::new(ErrorKind::InvalidInput, "queue name exceeds 64 bytes"));
+        }
         let request_message = RequestMessage {
             command,
             client_id: self.client_id,
-            queue_name: queue_name.clone(),
+            queue_name: queue_name.to_string(),
             payload_size: payload.len() as u64,
             payload,
         };
@@ -172,14 +211,19 @@ impl BrokerClient {
     }
     pub(crate) async fn receive(&self) -> Result<Vec<u8>, std::io::Error> {
         let mut buffer = BytesMut::with_capacity(1024*4);
+        let mut stream = self.stream.lock().await;
         loop {
-            let n = self.stream.lock().await.read_buf(&mut buffer).await?;
+            let n = stream.read_buf(&mut buffer).await?;
             if n == 0 {
                 return Err(std::io::Error::new(ErrorKind::UnexpectedEof, "server closed connection"));
             }
             if buffer.len() >= 9 {
                 let payload_size = u64::from_be_bytes(buffer[1..9].try_into().unwrap());
-                if buffer.len() >= payload_size as usize + 9 {
+                let payload_len: usize = payload_size.try_into()
+                    .map_err(|_| std::io::Error::new(ErrorKind::InvalidData, "payload size exceeds platform limit"))?;
+                let total = payload_len.checked_add(9)
+                    .ok_or_else(|| std::io::Error::new(ErrorKind::InvalidData, "payload size overflow"))?;
+                if buffer.len() >= total {
                     match Response::from_u8(buffer[0])? {
                         Response::Succeeded => {
                             let response = parse_message(&mut buffer)?;
@@ -187,8 +231,7 @@ impl BrokerClient {
                         }
                         Response::Failed => {
                             let response = parse_message(&mut buffer)?;
-                            let msg = String::from_utf8(response.payload)
-                                .unwrap_or_else(|_| "response returned error".to_string());
+                            let msg = parse_error_payload(&response.payload);
                             return Err(std::io::Error::new(ErrorKind::Other, msg));
                         }
                     }
@@ -197,7 +240,7 @@ impl BrokerClient {
         }
     }
 }
-pub async fn client_send(client: Arc<Mutex<BrokerClient>>, command: u8, payload: Vec<u8>, queue_name: &String) -> Result<Vec<u8>, std::io::Error> {
+pub async fn client_send(client: Arc<Mutex<BrokerClient>>, command: u8, payload: Vec<u8>, queue_name: &str) -> Result<Vec<u8>, std::io::Error> {
     let command = Request::from_u8(command)?;
     let broker = client.lock().await;
     broker.send(command, payload, queue_name).await?;


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                          
  - Parse server error responses as u16 error codes (matching server's `ErrorCode` enum) instead of misinterpreting them as UTF-8 strings                                                                                                                             
  - Hold the stream lock for the entire `receive()` loop instead of dropping/re-acquiring per iteration, preventing potential data loss                                                                                                                               
  - Add `try_into()` + `checked_add` for `payload_size` conversion, preventing silent truncation on 32-bit platforms and arithmetic overflow                                                                                                                          
  - Reject queue names exceeding 64 bytes with an explicit error instead of silent truncation                                                                                                                                                                         
  - Add `UpdateQ` command (11) to match the server                                                                                                                                                                                                                    
  - Propagate original error details in `connect()` and dequeue fallback path                                                                                                                                                                                         
  - Remove unnecessary `.clone()` calls; change `&String` → `&str`                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  ## Test plan                                                                                                                                                                                                                                                        
  - [ ] Build with `cargo build --release` — no new warnings beyond pre-existing ones                                                                                                                                                                               
  - [ ] Run `cargo test` — all tests pass                                                                                                                                                                                                                             
  - [ ] Manual test: send a request to a non-existent queue and verify the error message includes the numeric error code and human-readable description (e.g. `server error 100: queue hash not found`)                                                               
  - [ ] Manual test: pass a queue name longer than 64 bytes and verify it returns an `InvalidInput` error                                                                                                                                                             
  - [ ] Manual test: verify Dequeue, ListM, Enqueue, and UpdateQ commands work against a running DataBroker server                                                                                                                                                    
                                                                                                                                                                                                                                                                        🤖 Generated with [Claude Code](https://claude.com/claude-code)  