### PR TITLE
NetStats command (12) and QueueStat response parsing added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,16 @@
   - All other commands still return `bytes`.
 
 ### Added
+- `NetStats` command (12) — matches the server's queue statistics command. `send(client, 12, b"", "")` returns `list[QueueStat]`.
+- `QueueStat` Python class with fields `queue_name`, `total_messages`, `total_bytes`, `total_messages_locked`, `total_bytes_locked`.
+- `parse_stats_response()` parses the server's nested stats payload layout: `[4b count u32 BE][{4b stat_len u32 BE}{2b name_len u16 BE}{name}{8b total_messages}{8b total_bytes}{8b total_messages_locked}{8b total_bytes_locked}]*` (counters are 64-bit on the server's supported targets).
 - `UpdateQ` command (11) — matches the server's queue-config update command. Payload is a `NetQueueConfig` binary blob (flags byte + optional `auto_fail` bool + optional `fail_timeout` u64 BE).
 - `MessageMeta` Python class with fields `id`, `publisher_id`, `timestamp`, `locked_by` — parsed from the server's 56-byte Meta format.
 - Client-side parsing of server Meta on Dequeue and ListM responses.
 - `BrokerClient` now carries a `client_id: u128` generated at connect time (system clock based).
 - New request commands mirroring the server: `CreateQ (3)`, `DeleteQ (4)`, `ListM (5)`, `DeleteM (6)`, `Succeeded (7)`, `Failed (8)`, `Requeue (9)`, `UpdateM (10)`.
 - Queue name is null-padded to 64 bytes on the wire as required by the server.
-- `error_code_message()` maps all 18 server error codes (0–303) to human-readable strings.
+- `error_code_message()` maps all 19 server error codes (0–303) to human-readable strings, including `QueueStatsFailed (105)`.
 
 ### Fixed
 - Failed server responses (2-byte big-endian `u16` error codes) are now correctly parsed and mapped to human-readable error messages, instead of being misinterpreted as UTF-8 strings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,16 +36,18 @@ cargo run -- --address 192.168.1.5:9000
 - `BrokerClient`: wraps a TCP stream and a `client_id: u128`; wrapped in `Arc<Mutex<>>` for thread safety
 - `PyBrokerClient`: thin PyO3-visible wrapper around `BrokerClient`
 - `MessageMeta`: PyO3-visible struct with fields `id: u128`, `publisher_id: u128`, `timestamp: u64`, `locked_by: Option<u128>` — parsed from the server's 56-byte Meta format (big-endian, `u128::MAX` → `None` for `locked_by`)
+- `QueueStat`: PyO3-visible struct with fields `queue_name: String`, `total_messages: u64`, `total_bytes: u64`, `total_messages_locked: u64`, `total_bytes_locked: u64` — parsed from the server's `NetStats` response (nested `[u32 count][{u32 stat_len}{u16 name_len}{name}{4×u64 counters}]` layout, all big-endian)
 - `client_send()` sends a request (any command) with a `Vec<u8>` payload, then awaits and returns the server's response payload as `Vec<u8>`
 - Failed responses are parsed as 2-byte big-endian `u16` error codes matching the server's `ErrorCode` enum, and converted to human-readable error messages via `error_code_message()`
 - Response parsing varies by command:
   - **Dequeue (2)**: returns `tuple(MessageMeta, bytes)` — meta separated from payload
   - **ListM (5)**: returns `list[MessageMeta]` — one entry per 56-byte chunk
+  - **NetStats (12)**: returns `list[QueueStat]` — one entry per queue
   - **All others**: returns raw `bytes`
 - Binary protocol (big-endian, matches DataBroker server):
   - Request: `[1 byte command][16 bytes client_id u128 BE][8 bytes payload_size u64 BE][64 bytes queue_name null-padded][payload]`
   - Response: `[1 byte status][8 bytes payload_size u64 BE][payload]`
-  - Request commands: `Enqueue = 1`, `Dequeue = 2`, `CreateQ = 3`, `DeleteQ = 4`, `ListM = 5`, `DeleteM = 6`, `Succeeded = 7`, `Failed = 8`, `Requeue = 9`, `UpdateM = 10`, `UpdateQ = 11`
+  - Request commands: `Enqueue = 1`, `Dequeue = 2`, `CreateQ = 3`, `DeleteQ = 4`, `ListM = 5`, `DeleteM = 6`, `Succeeded = 7`, `Failed = 8`, `Requeue = 9`, `UpdateM = 10`, `UpdateQ = 11`, `NetStats = 12`
   - Response codes: `Succeeded = 1`, `Failed = 2`
 - `client_id` is generated at connect time from the system clock (secs << 64 | subsec_nanos)
 - `receive()` holds the stream lock for the entire read loop (not per-iteration) and guards `buffer.len() >= 9 + payload_size` before calling `parse_message`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "DataBrokerClient"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "DataBrokerClient"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3_asyncio::tokio::init_with_runtime;
 use tokio::runtime::Runtime;
-use crate::net::client::{client_connect, client_send, PyBrokerClient, MessageMeta, parse_list_response, parse_dequeue_response};
+use crate::net::client::{client_connect, client_send, PyBrokerClient, MessageMeta, QueueStat, parse_list_response, parse_dequeue_response, parse_stats_response};
 mod net;
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
@@ -56,6 +56,18 @@ unsafe fn send<'py>(py: Python<'py>, client: &PyBrokerClient, command: u8, paylo
                                 Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!("dequeue parse failed: {err}"))),
                             }
                         }
+                        // NetStats - return list[QueueStat]
+                        12 => {
+                            match parse_stats_response(&response) {
+                                Ok(stats) => {
+                                    let py_list: Vec<PyObject> = stats.into_iter()
+                                        .map(|s| Py::new(py, s).unwrap().into_py(py))
+                                        .collect();
+                                    Ok(py_list.into_py(py))
+                                }
+                                Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!("stats parse failed: {err}"))),
+                            }
+                        }
                         // Everything else - return raw bytes
                         _ => Ok(response.into_py(py)),
                     }
@@ -70,6 +82,7 @@ fn data_broker_client(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     let rt: &'static Runtime = get_runtime();
     let _ = init_with_runtime(rt);
     m.add_class::<MessageMeta>()?;
+    m.add_class::<QueueStat>()?;
     m.add_function(wrap_pyfunction!(connect, m)?)?;
     m.add_function(wrap_pyfunction!(send, m)?)?;
     Ok(())

--- a/src/net/client.rs
+++ b/src/net/client.rs
@@ -40,6 +40,20 @@ impl MessageMeta {
         MessageMeta { id, publisher_id, timestamp, locked_by }
     }
 }
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct QueueStat {
+    #[pyo3(get)]
+    pub queue_name: String,
+    #[pyo3(get)]
+    pub total_messages: u64,
+    #[pyo3(get)]
+    pub total_bytes: u64,
+    #[pyo3(get)]
+    pub total_messages_locked: u64,
+    #[pyo3(get)]
+    pub total_bytes_locked: u64,
+}
 pub fn parse_list_response(payload: &[u8]) -> Vec<MessageMeta> {
     payload.chunks_exact(META_SIZE)
         .map(MessageMeta::from_bytes)
@@ -52,6 +66,48 @@ pub fn parse_dequeue_response(payload: &[u8]) -> Result<(MessageMeta, Vec<u8>), 
     let meta = MessageMeta::from_bytes(&payload[..META_SIZE]);
     let data = payload[META_SIZE..].to_vec();
     Ok((meta, data))
+}
+/// Parse NetStats response. Layout (big-endian):
+///   [4b count u32][for each stat: [4b length u32][stat bytes]]
+/// stat bytes layout:
+///   [2b name_len u16][name bytes][8b total_messages][8b total_bytes]
+///   [8b total_messages_locked][8b total_bytes_locked]
+/// The server writes the four counters via `usize::to_be_bytes()`; on the 64-bit
+/// Linux/Windows targets the server ships for, `usize` is 8 bytes.
+pub fn parse_stats_response(payload: &[u8]) -> Result<Vec<QueueStat>, std::io::Error> {
+    let short = || std::io::Error::new(ErrorKind::InvalidData, "stats response truncated");
+    if payload.len() < 4 { return Err(short()); }
+    let count = u32::from_be_bytes(payload[0..4].try_into().unwrap()) as usize;
+    let mut offset = 4usize;
+    let mut stats = Vec::with_capacity(count);
+    for _ in 0..count {
+        if offset + 4 > payload.len() { return Err(short()); }
+        let stat_len = u32::from_be_bytes(payload[offset..offset+4].try_into().unwrap()) as usize;
+        offset += 4;
+        if offset + stat_len > payload.len() { return Err(short()); }
+        let stat = &payload[offset..offset+stat_len];
+        offset += stat_len;
+
+        if stat.len() < 2 { return Err(short()); }
+        let name_len = u16::from_be_bytes(stat[0..2].try_into().unwrap()) as usize;
+        let mut p = 2usize;
+        if p + name_len + 32 > stat.len() { return Err(short()); }
+        let queue_name = String::from_utf8(stat[p..p+name_len].to_vec())
+            .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, format!("invalid utf-8 in queue name: {e}")))?;
+        p += name_len;
+        let total_messages        = u64::from_be_bytes(stat[p..p+8].try_into().unwrap()); p += 8;
+        let total_bytes           = u64::from_be_bytes(stat[p..p+8].try_into().unwrap()); p += 8;
+        let total_messages_locked = u64::from_be_bytes(stat[p..p+8].try_into().unwrap()); p += 8;
+        let total_bytes_locked    = u64::from_be_bytes(stat[p..p+8].try_into().unwrap());
+        stats.push(QueueStat {
+            queue_name,
+            total_messages,
+            total_bytes,
+            total_messages_locked,
+            total_bytes_locked,
+        });
+    }
+    Ok(stats)
 }
 #[repr(u8)]
 #[derive(Debug, Clone)]
@@ -67,6 +123,7 @@ pub enum Request {
     Requeue = 9,
     UpdateM = 10,
     UpdateQ = 11,
+    NetStats = 12,
 }
 impl Request {
     pub fn from_u8(value: u8) -> Result<Self, std::io::Error> {
@@ -82,6 +139,7 @@ impl Request {
             9 => Ok(Request::Requeue),
             10 => Ok(Request::UpdateM),
             11 => Ok(Request::UpdateQ),
+            12 => Ok(Request::NetStats),
             _ => Err(std::io::Error::new(ErrorKind::InvalidInput, format!("unknown command: {}", value))),
         }
     }
@@ -152,6 +210,7 @@ fn error_code_message(code: u16) -> &'static str {
         102 => "queue already exists",
         103 => "queue does not exist",
         104 => "queue is empty",
+        105 => "failed to get queue stats",
         200 => "payload missing message id",
         201 => "no such message id",
         202 => "message already locked",


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                                        Adds support for the server's NetStats = 12 command, which was previously missing from the client. Python callers can now fetch per-queue statistics and receive them as a typed list[QueueStat].                                                                                                                                                                                                                                                                                                                                         
  Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - Request::NetStats = 12 added to the command enum and from_u8 dispatch in src/net/client.rs.                                                                                                                                                                       
  - QueueStat pyclass exposed to Python with fields: queue_name, total_messages, total_bytes, total_messages_locked, total_bytes_locked.
  - parse_stats_response() decodes the server's nested payload layout (big-endian):                                                                                                                                                                                   
  [u32 count]                                                                                                                                                                                                                                                         
    [u32 stat_len][u16 name_len][name bytes]                                                                                                                                                                                                                          
    [u64 total_messages][u64 total_bytes]                                                                                                                                                                                                                             
    [u64 total_messages_locked][u64 total_bytes_locked]                                                                                                                                                                                                               
  - All offsets are bounds-checked before indexing; truncated payloads return InvalidData instead of panicking.                                                                                                                                                       
  - lib.rs routing: command 12 now returns list[QueueStat] instead of raw bytes. QueueStat is registered on the Python module.                                                                                                                                        
  - Error code 105 (QueueStatsFailed) added to error_code_message() so failed NetStats responses produce a readable message.                                                                                                                                          
                                                                                                                                                                                                                                                                        Protocol conformance                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                      
  Cross-checked against DataBroker/src/net/server.rs (NetStats handler) and DataBroker/src/net/net_stats.rs (StatWatcher::to_bytes / StatMessage::to_bytes). Counters are serialized server-side via usize::to_be_bytes(), which is 8 bytes on the 64-bit               Linux/Windows targets the server ships for — the client decodes them as u64.
                                                                                                                                                                                                                                                                      
  Review          

  A separate review pass was run against the full client (client.rs + lib.rs) cross-referenced with the server. No bugs, protocol mismatches, concurrency issues, or panics were found. Framing, bounds checks, dequeue/list parsing, stream-lock discipline, and       error-code mapping all verified correct.
                                                                                                                                                                                                                                                                      
  Docs            

  - CLAUDE.md: QueueStat architecture note, NetStats response mapping, and command list updated to include NetStats = 12.                                                                                                                                             
  - CHANGELOG.md: entries under [Unreleased] → Added for the new command, pyclass, and parser; error-code count bumped to 19.
                                                                                                                                                                                                                                                                        Python usage    
                                                                                                                                                                                                                                                                      
  import data_broker_client as db
  client = await db.connect("127.0.0.1:8080")                                                                                                                                                                                                                         
  stats = await db.send(client, 12, b"", "")  # list[QueueStat]
  for s in stats:                                                                                                                                                                                                                                                     
      print(s.queue_name, s.total_messages, s.total_bytes)
                                                                                                                                                                                                                                                                        Test plan       
                                                                                                                                                                                                                                                                      
  - cargo build --release succeeds (verified locally)                                                                                                                                                                                                                 
  - Build wheel via maturin build --release --skip-auditwheel -m Cargo.toml
  - Run against a live DataBroker server with several queues; verify send(client, 12, b"", "") returns one QueueStat per queue with correct counters                                                                                                                  
  - Verify error path: stop server mid-call and confirm failed responses surface the "failed to get queue stats" (code 105) message